### PR TITLE
검수 페이지 detail에서 수정 후 success_url을 detail로 가게 설정

### DIFF
--- a/photo/templates/photo/photo_create.html
+++ b/photo/templates/photo/photo_create.html
@@ -25,7 +25,7 @@
             {% endif %}
             <!-- 오류표시 End -->
             <div class="mb-3">
-                <input required name="image" type="file" multiple class="form-control-file">
+                <input required name="image" type="file" accept="image/jpg, image/jpeg, image/png" multiple class="form-control-file">
             </div>
             <input type="submit" value="업로드" class="btn btn-success">
         </form>

--- a/photo/views.py
+++ b/photo/views.py
@@ -1,4 +1,5 @@
 # Create your views here.
+from django.urls import reverse_lazy, reverse
 from django.views.generic import ListView, CreateView, UpdateView, DeleteView, DetailView
 
 from photo.forms import ShoesPhotoForm, TopCategoryForm, SubCategoryForm, LabeledPhotoForm
@@ -97,7 +98,10 @@ class LabeledPhotoUpdate(UpdateView):
     model = LabeledPhoto
     form_class = LabeledPhotoForm
     template_name = 'label/labeled_photo_update.html'
-    success_url = '/labeled/list'
+    success_url = reverse_lazy('photo:labeled_detail')
+
+    def get_success_url(self):
+        return reverse('photo:labeled_detail', kwargs={'pk': self.object.pk})
 
 
 class LabeledPhotoDelete(DeleteView):


### PR DESCRIPTION
1. labeled_photo_detail의 success_url을 자신의 상세보기 페이지로 갈 수 있게 설정했음.
2. 이미지 업로드 시 이미지 확장자 파일만 보이도록 설정(추후 이미지 파일인지 확인하는 과정 추가 예정)